### PR TITLE
appveyor.yml CI config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,70 @@
+version: 0.9.1.{build}
+image: Visual Studio 2015
+
+
+environment:
+  matrix:
+    - PlatformToolset: v140_xp
+
+platform:
+    #- x64
+    - x86
+
+configuration:
+    - Release
+    - Debug
+
+install:
+    - if "%platform%"=="x64" set archi=amd64
+    - if "%platform%"=="x86" set archi=x86
+    - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %archi%
+    - nuget restore "%APPVEYOR_BUILD_FOLDER%"\NppMenuSearch\packages.config -PackagesDirectory "%APPVEYOR_BUILD_FOLDER%"\packages
+
+
+build:
+    parallel: true                  # enable MSBuild parallel builds
+    verbosity: minimal
+
+build_script:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - msbuild NppMenuSearch.sln /m /p:configuration="%configuration%" /p:platform="%platform%" /p:PlatformToolset="%PlatformToolset%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
+after_build:
+    - cd "%APPVEYOR_BUILD_FOLDER%"\NppMenuSearch
+    - ps: >-
+
+        if ($env:PLATFORM -eq "x64" -and $env:CONFIGURATION -eq "Release") {
+            #Push-AppveyorArtifact "bin\$env:PLATFORM\$env:CONFIGURATION\" -FileName NppMenuSearch.dll
+        }
+
+        if ($env:PLATFORM -eq "x86" -and $env:CONFIGURATION -eq "Release") {
+            Push-AppveyorArtifact "bin\$env:PLATFORM\$env:CONFIGURATION\NppMenuSearch.dll" -FileName NppMenuSearch.dll
+        }
+
+        if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release" -and $env:PLATFORMTOOLSET -eq "v140_xp") {
+            if($env:PLATFORM -eq "x64"){
+            $ZipFileName = "NppMenuSearch_$($env:APPVEYOR_REPO_TAG_NAME)_x64.zip"
+            7z a $ZipFileName bin\$env:PLATFORM\$env:CONFIGURATION\NppMenuSearch.dll
+            }
+            if($env:PLATFORM -eq "x86"){
+            $ZipFileName = "NppMenuSearch_$($env:APPVEYOR_REPO_TAG_NAME)_x86.zip"
+            7z a $ZipFileName bin\$env:PLATFORM\$env:CONFIGURATION\NppMenuSearch.dll
+            }
+        }
+
+artifacts:
+  - path: NppMenuSearch_*.zip
+    name: releases
+
+deploy:
+    provider: GitHub
+    auth_token:
+        secure: !!TODO, see https://www.appveyor.com/docs/deployment/github/#provider-settings!!
+    artifact: releases
+    draft: false
+    prerelease: false
+    force_update: true
+    on:
+        appveyor_repo_tag: true
+        PlatformToolset: v140_xp
+        configuration: Release


### PR DESCRIPTION
, see https://ci.appveyor.com/project/chcg/nppmenusearch/build/0.9.1.5

See https://github.com/kbilsted/NotepadPlusPlusPluginPack.Net for a successor of UnmanagedExports with x64 version in mind

See https://www.appveyor.com/docs/deployment/github/#provider-settings for an automated release from appveyor build to github on git tagging

Maybe consider to make the plugin available via the PluginManager, see for administration https://npppm.bruderste.in/welcome