### PR TITLE
Appveyor + x64

### DIFF
--- a/NppMenuSearch.sln
+++ b/NppMenuSearch.sln
@@ -5,12 +5,18 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NppMenuSearch", "NppMenuSea
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Debug|x64.ActiveCfg = Debug|x64
+		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Debug|x64.Build.0 = Debug|x64
 		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Debug|x86.ActiveCfg = Debug|x86
 		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Debug|x86.Build.0 = Debug|x86
+		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Release|x64.ActiveCfg = Release|x64
+		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Release|x64.Build.0 = Release|x64
 		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Release|x86.ActiveCfg = Release|x86
 		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection

--- a/NppMenuSearch/DialogHelper.cs
+++ b/NppMenuSearch/DialogHelper.cs
@@ -95,7 +95,7 @@ namespace NppMenuSearch
                         return false;
 
                     case "ListBox":
-                        if (Win32.GetWindowLong(hwndFormChild, Win32.GWL_ID) == (int)NppResources.IDC_LIST_DLGTITLE)
+                        if (Win32.GetWindowLongPtr(hwndFormChild, Win32.GWL_ID) ==(IntPtr) NppResources.IDC_LIST_DLGTITLE)
                         {
                             hwndTabList = hwndFormChild;
                             return false;

--- a/NppMenuSearch/DialogItem.cs
+++ b/NppMenuSearch/DialogItem.cs
@@ -105,7 +105,7 @@ namespace NppMenuSearch
                         return true;
 
                     if (item.Text != "" &&
-                        Win32.BS_GROUPBOX == (Win32.BS_TYPEMASK & Win32.GetWindowLong(descendent, Win32.GWL_STYLE)))
+                        Win32.BS_GROUPBOX == (Win32.BS_TYPEMASK & (int)Win32.GetWindowLongPtr(descendent, Win32.GWL_STYLE)))
                     {
                         if (Win32.GetClassName(descendent) == "Button")
                         {

--- a/NppMenuSearch/Forms/ToolbarSearchForm.cs
+++ b/NppMenuSearch/Forms/ToolbarSearchForm.cs
@@ -174,10 +174,10 @@ namespace NppMenuSearch.Forms
                 {
                     InitToolbar();
 
-                    Win32.SetWindowLong(
+                    Win32.SetWindowLongPtr(
                         Handle,
                         Win32.GWL_STYLE,
-                        Win32.WS_CHILD | Win32.GetWindowLong(Handle, Win32.GWL_STYLE));
+                        (IntPtr)(Win32.WS_CHILD | (int)Win32.GetWindowLongPtr(Handle, Win32.GWL_STYLE)));
                 }
 
                 Win32.REBARBANDINFO band = new Win32.REBARBANDINFO();

--- a/NppMenuSearch/NppMenuSearch.csproj
+++ b/NppMenuSearch/NppMenuSearch.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>NppMenuSearch</RootNamespace>
     <AssemblyName>NppMenuSearch</AssemblyName>
     <OutputPath>bin\Debug\</OutputPath>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <OldToolsVersion>3.5</OldToolsVersion>
@@ -63,6 +63,24 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRuleSetDirectories>;C:\Program Files\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\\Rule Sets</CodeAnalysisRuleSetDirectories>
     <CodeAnalysisRuleDirectories>;C:\Program Files\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\FxCop\\Rules</CodeAnalysisRuleDirectories>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="RGiesecke.DllExport.Metadata, Version=1.0.0.0, Culture=neutral, PublicKeyToken=8f52d83c1a22df51, processorArchitecture=MSIL">

--- a/NppMenuSearch/NppPluginNETHelper.cs
+++ b/NppMenuSearch/NppPluginNETHelper.cs
@@ -75,17 +75,17 @@ namespace NppPluginNET
                 RtlMoveMemory(newPointer, _nativePointer, oldSize);
                 Marshal.FreeHGlobal(_nativePointer);
             }
-            IntPtr ptrPosNewItem = (IntPtr)((int)newPointer + oldSize);
+            IntPtr ptrPosNewItem = (IntPtr)(newPointer.ToInt64() + oldSize);
             byte[] aB = Encoding.Unicode.GetBytes(funcItem._itemName + "\0");
             Marshal.Copy(aB, 0, ptrPosNewItem, aB.Length);
-            ptrPosNewItem = (IntPtr)((int)ptrPosNewItem + 128);
+            ptrPosNewItem = (IntPtr)(ptrPosNewItem.ToInt64() + 128);
             IntPtr p = (funcItem._pFunc != null) ? Marshal.GetFunctionPointerForDelegate(funcItem._pFunc) : IntPtr.Zero;
             Marshal.WriteIntPtr(ptrPosNewItem, p);
-            ptrPosNewItem = (IntPtr)((int)ptrPosNewItem + IntPtr.Size);
+            ptrPosNewItem = (IntPtr)(ptrPosNewItem.ToInt64() + IntPtr.Size);
             Marshal.WriteInt32(ptrPosNewItem, funcItem._cmdID);
-            ptrPosNewItem = (IntPtr)((int)ptrPosNewItem + 4);
+            ptrPosNewItem = (IntPtr)(ptrPosNewItem.ToInt64() + 4);
             Marshal.WriteInt32(ptrPosNewItem, Convert.ToInt32(funcItem._init2Check));
-            ptrPosNewItem = (IntPtr)((int)ptrPosNewItem + 4);
+            ptrPosNewItem = (IntPtr)(ptrPosNewItem.ToInt64() + 4);
             if (funcItem._pShKey._key != 0)
             {
                 IntPtr newShortCutKey = Marshal.AllocHGlobal(4);
@@ -104,15 +104,15 @@ namespace NppPluginNET
             {
                 FuncItem updatedItem = new FuncItem();
                 updatedItem._itemName = _funcItems[i]._itemName;
-                ptrPosItem = (IntPtr)((int)ptrPosItem + 128);
+                ptrPosItem = (IntPtr)(ptrPosItem.ToInt64() + 128);
                 updatedItem._pFunc = _funcItems[i]._pFunc;
-                ptrPosItem = (IntPtr)((int)ptrPosItem + IntPtr.Size);
+                ptrPosItem = (IntPtr)(ptrPosItem.ToInt64() + IntPtr.Size);
                 updatedItem._cmdID = Marshal.ReadInt32(ptrPosItem);
-                ptrPosItem = (IntPtr)((int)ptrPosItem + 4);
+                ptrPosItem = (IntPtr)(ptrPosItem.ToInt64() + 4);
                 updatedItem._init2Check = _funcItems[i]._init2Check;
-                ptrPosItem = (IntPtr)((int)ptrPosItem + 4);
+                ptrPosItem = (IntPtr)(ptrPosItem.ToInt64() + 4);
                 updatedItem._pShKey = _funcItems[i]._pShKey;
-                ptrPosItem = (IntPtr)((int)ptrPosItem + IntPtr.Size);
+                ptrPosItem = (IntPtr)(ptrPosItem.ToInt64() + IntPtr.Size);
 
                 _funcItems[i] = updatedItem;
             }
@@ -1145,7 +1145,7 @@ namespace NppPluginNET
 		 * hwndFrom is really an environment specific window handle or pointer
 		 * but most clients of Scintilla.h do not have this type visible. */
         public IntPtr hwndFrom;
-        public uint idFrom;
+        public IntPtr idFrom;
         public uint code;
     }
 
@@ -1161,8 +1161,8 @@ namespace NppPluginNET
         public int length;                /* SCN_MODIFIED */
         public int linesAdded;            /* SCN_MODIFIED */
         public int message;                /* SCN_MACRORECORD */
-        public uint wParam;                /* SCN_MACRORECORD */
-        public int lParam;                /* SCN_MACRORECORD */
+        public IntPtr wParam;                /* SCN_MACRORECORD */
+        public IntPtr lParam;                /* SCN_MACRORECORD */
         public int line;                /* SCN_MODIFIED */
         public int foldLevelNow;        /* SCN_MODIFIED */
         public int foldLevelPrev;        /* SCN_MODIFIED */
@@ -2404,6 +2404,17 @@ namespace NppPluginNET
 
         [DllImport("user32.dll")]
         public static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
+
+        [DllImport("user32.dll", EntryPoint = "GetWindowLongPtr")]
+        private static extern IntPtr GetWindowLongPtr64(IntPtr hWnd, int nIndex);
+
+        public static IntPtr GetWindowLongPtr(IntPtr hWnd, int nIndex)
+        {
+            if (IntPtr.Size == 8)
+                return GetWindowLongPtr64(hWnd, nIndex);
+            else
+                return new IntPtr(GetWindowLong(hWnd, nIndex));
+        }
 
         [DllImport("user32.dll", EntryPoint = "SetWindowLongPtr")]
         private static extern IntPtr SetWindowLongPtr64(IntPtr hWnd, int nIndex, IntPtr dwNewLong);

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
     - PlatformToolset: v140_xp
 
 platform:
-    #- x64
+    - x64
     - x86
 
 configuration:
@@ -34,7 +34,7 @@ after_build:
     - ps: >-
 
         if ($env:PLATFORM -eq "x64" -and $env:CONFIGURATION -eq "Release") {
-            #Push-AppveyorArtifact "bin\$env:PLATFORM\$env:CONFIGURATION\" -FileName NppMenuSearch.dll
+            Push-AppveyorArtifact "bin\$env:PLATFORM\$env:CONFIGURATION\NppMenuSearch.dll" -FileName NppMenuSearch.dll
         }
 
         if ($env:PLATFORM -eq "x86" -and $env:CONFIGURATION -eq "Release") {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,70 @@
+version: 0.9.1.{build}
+image: Visual Studio 2015
+
+
+environment:
+  matrix:
+    - PlatformToolset: v140_xp
+
+platform:
+    #- x64
+    - x86
+
+configuration:
+    - Release
+    - Debug
+
+install:
+    - if "%platform%"=="x64" set archi=amd64
+    - if "%platform%"=="x86" set archi=x86
+    - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %archi%
+    - nuget restore "%APPVEYOR_BUILD_FOLDER%"\NppMenuSearch\packages.config -PackagesDirectory "%APPVEYOR_BUILD_FOLDER%"\packages
+
+
+build:
+    parallel: true                  # enable MSBuild parallel builds
+    verbosity: minimal
+
+build_script:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - msbuild NppMenuSearch.sln /m /p:configuration="%configuration%" /p:platform="%platform%" /p:PlatformToolset="%PlatformToolset%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
+after_build:
+    - cd "%APPVEYOR_BUILD_FOLDER%"\NppMenuSearch
+    - ps: >-
+
+        if ($env:PLATFORM -eq "x64" -and $env:CONFIGURATION -eq "Release") {
+            #Push-AppveyorArtifact "bin\$env:PLATFORM\$env:CONFIGURATION\" -FileName NppMenuSearch.dll
+        }
+
+        if ($env:PLATFORM -eq "x86" -and $env:CONFIGURATION -eq "Release") {
+            Push-AppveyorArtifact "bin\$env:PLATFORM\$env:CONFIGURATION\NppMenuSearch.dll" -FileName NppMenuSearch.dll
+        }
+
+        if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release" -and $env:PLATFORMTOOLSET -eq "v140_xp") {
+            if($env:PLATFORM -eq "x64"){
+            $ZipFileName = "NppMenuSearch_$($env:APPVEYOR_REPO_TAG_NAME)_x64.zip"
+            7z a $ZipFileName bin\$env:PLATFORM\$env:CONFIGURATION\NppMenuSearch.dll
+            }
+            if($env:PLATFORM -eq "x86"){
+            $ZipFileName = "NppMenuSearch_$($env:APPVEYOR_REPO_TAG_NAME)_x86.zip"
+            7z a $ZipFileName bin\$env:PLATFORM\$env:CONFIGURATION\NppMenuSearch.dll
+            }
+        }
+
+artifacts:
+  - path: NppMenuSearch_*.zip
+    name: releases
+
+deploy:
+    provider: GitHub
+    auth_token:
+        secure: !!TODO, see https://www.appveyor.com/docs/deployment/github/#provider-settings!!
+    artifact: releases
+    draft: false
+    prerelease: false
+    force_update: true
+    on:
+        appveyor_repo_tag: true
+        PlatformToolset: v140_xp
+        configuration: Release


### PR DESCRIPTION
takes care of #1 

- added appveyor.yml CI config from PR #5, adapted for x64
- x64 adaptations, plugin appears in menu and seems to be functional at some basic tests
, see also http://pinvoke.net/default.aspx/user32.GetWindowLongPtr
- TargetFrameworkVersion needs to be changed to 4.0 for x64 support

, build see https://ci.appveyor.com/project/chcg/nppmenusearch/build/0.9.1.7