### PR TITLE
#25 fixup: designer's components collection might be null 

### DIFF
--- a/NppMenuSearch/Forms/FlyingSearchForm.cs
+++ b/NppMenuSearch/Forms/FlyingSearchForm.cs
@@ -15,6 +15,9 @@ namespace NppMenuSearch.Forms
 
             ResultsPopup = new ResultsPopup();
             ResultsPopup.OwnerTextBox = txtSearch;
+
+            if (components == null)
+                components = new System.ComponentModel.Container();
             components.Add(ResultsPopup);
         }
 


### PR DESCRIPTION
Hi, 

I'd like to address the #25 issue. It looks like with a hidden toolbar on the most recent NPP, a Designer's auto-generated FlyingSearchForm.components may be null. Perhaps, in case if we want to manually edit it, it's reasonable to verify whether it's null and create it when needed. 

This resolved an issue for me on x86 for NPP v.7.8.7 and with the most recent NppMenuSearch version. 