### PR TITLE
Using Ctrl+BS to remove previous word in txtSearch instead of inserting an unreadable symbol

### DIFF
--- a/NppMenuSearch/Forms/FlyingSearchForm.cs
+++ b/NppMenuSearch/Forms/FlyingSearchForm.cs
@@ -87,6 +87,15 @@ namespace NppMenuSearch.Forms
 
         private bool suppressKeyPress;
 
+        private string RemoveLastWord(string S)
+        {
+            int n = S.Length - 1;
+            while (n >= 0 && Char.IsWhiteSpace(S[n])) { --n; } // skipping the trailing spaces
+            while (n >= 0 && !Char.IsWhiteSpace(S[n])) { --n; } // skipping the last word
+            while (n >= 0 && Char.IsWhiteSpace(S[n])) { --n; } // skipping the spaces before the last word
+            return (n >= 0) ? S.Substring(0, n + 1) : "";
+        }
+
         private void txtSearch_KeyDown(object sender, KeyEventArgs e)
         {
             suppressKeyPress = false;
@@ -112,7 +121,9 @@ namespace NppMenuSearch.Forms
                     if (e.Control)
                     {
                         // Ctrl+BackSpace
-                        txtSearch.Text = "";
+                        txtSearch.Text = RemoveLastWord(txtSearch.Text);
+                        int n = txtSearch.Text.Length;
+                        txtSearch.Select(n, n);
                     }
                     break;
             }

--- a/NppMenuSearch/Forms/FlyingSearchForm.cs
+++ b/NppMenuSearch/Forms/FlyingSearchForm.cs
@@ -107,6 +107,14 @@ namespace NppMenuSearch.Forms
                     e.Handled = true;
                     suppressKeyPress = true;
                     break;
+
+                case Keys.Back:
+                    if (e.Control)
+                    {
+                        // Ctrl+BackSpace
+                        txtSearch.Text = "";
+                    }
+                    break;
             }
         }
 
@@ -116,6 +124,14 @@ namespace NppMenuSearch.Forms
             {
                 suppressKeyPress = false;
                 e.Handled = true;
+            }
+            else
+            {
+                if (e.KeyChar == '\x7F') // 0x7F corresponds to Ctrl+BackSpace. Why? Ask Microsoft...
+                {
+                    e.KeyChar = '\x00';
+                    e.Handled = true;
+                }
             }
         }
 

--- a/NppMenuSearch/Forms/FlyingSearchForm.cs
+++ b/NppMenuSearch/Forms/FlyingSearchForm.cs
@@ -117,7 +117,7 @@ namespace NppMenuSearch.Forms
                         if (txtSearch.SelectionLength == 0)
                         {
                             int len = txtSearch.Text.Length;
-                            txtSearch.Text = txtSearch.Text.RemovePrevioustWord(pos);
+                            txtSearch.Text = txtSearch.Text.RemovePreviousWord(pos);
                             pos -= (len - txtSearch.Text.Length);
                         }
                         else

--- a/NppMenuSearch/Forms/FlyingSearchForm.cs
+++ b/NppMenuSearch/Forms/FlyingSearchForm.cs
@@ -87,13 +87,13 @@ namespace NppMenuSearch.Forms
 
         private bool suppressKeyPress;
 
-        private string RemoveLastWord(string S)
+        private string RemovePrevioustWord(string S, int pos)
         {
-            int n = S.Length - 1;
+            int n = ((pos <= S.Length) ? pos : S.Length) - 1;
             while (n >= 0 && Char.IsWhiteSpace(S[n])) { --n; } // skipping the trailing spaces
             while (n >= 0 && !Char.IsWhiteSpace(S[n])) { --n; } // skipping the last word
             while (n >= 0 && Char.IsWhiteSpace(S[n])) { --n; } // skipping the spaces before the last word
-            return (n >= 0) ? S.Substring(0, n + 1) : "";
+            return S.Substring(0, n + 1) + S.Substring(pos);
         }
 
         private void txtSearch_KeyDown(object sender, KeyEventArgs e)
@@ -121,9 +121,18 @@ namespace NppMenuSearch.Forms
                     if (e.Control)
                     {
                         // Ctrl+BackSpace
-                        txtSearch.Text = RemoveLastWord(txtSearch.Text);
-                        int n = txtSearch.Text.Length;
-                        txtSearch.Select(n, n);
+                        int pos = txtSearch.SelectionStart;
+                        if (txtSearch.SelectionLength == 0)
+                        {
+                            int len = txtSearch.Text.Length;
+                            txtSearch.Text = RemovePrevioustWord(txtSearch.Text, pos);
+                            pos -= (len - txtSearch.Text.Length);
+                        }
+                        else
+                        {
+                            txtSearch.Text = txtSearch.Text.Substring(0, pos) + txtSearch.Text.Substring(pos + txtSearch.SelectionLength);
+                        }
+                        txtSearch.Select(pos, 0);
                     }
                     break;
             }

--- a/NppMenuSearch/Forms/FlyingSearchForm.cs
+++ b/NppMenuSearch/Forms/FlyingSearchForm.cs
@@ -87,15 +87,6 @@ namespace NppMenuSearch.Forms
 
         private bool suppressKeyPress;
 
-        private string RemovePrevioustWord(string S, int pos)
-        {
-            int n = ((pos <= S.Length) ? pos : S.Length) - 1;
-            while (n >= 0 && Char.IsWhiteSpace(S[n])) { --n; } // skipping the trailing spaces
-            while (n >= 0 && !Char.IsWhiteSpace(S[n])) { --n; } // skipping the last word
-            while (n >= 0 && Char.IsWhiteSpace(S[n])) { --n; } // skipping the spaces before the last word
-            return S.Substring(0, n + 1) + S.Substring(pos);
-        }
-
         private void txtSearch_KeyDown(object sender, KeyEventArgs e)
         {
             suppressKeyPress = false;
@@ -121,11 +112,12 @@ namespace NppMenuSearch.Forms
                     if (e.Control)
                     {
                         // Ctrl+BackSpace
+                        suppressKeyPress = true; // Ctrl+BackSpace triggers a KeyPress with e.KeyChar == '\x7F'
                         int pos = txtSearch.SelectionStart;
                         if (txtSearch.SelectionLength == 0)
                         {
                             int len = txtSearch.Text.Length;
-                            txtSearch.Text = RemovePrevioustWord(txtSearch.Text, pos);
+                            txtSearch.Text = txtSearch.Text.RemovePrevioustWord(pos);
                             pos -= (len - txtSearch.Text.Length);
                         }
                         else
@@ -144,14 +136,6 @@ namespace NppMenuSearch.Forms
             {
                 suppressKeyPress = false;
                 e.Handled = true;
-            }
-            else
-            {
-                if (e.KeyChar == '\x7F') // 0x7F corresponds to Ctrl+BackSpace. Why? Ask Microsoft...
-                {
-                    e.KeyChar = '\x00';
-                    e.Handled = true;
-                }
             }
         }
 

--- a/NppMenuSearch/Forms/ToolbarSearchForm.cs
+++ b/NppMenuSearch/Forms/ToolbarSearchForm.cs
@@ -321,6 +321,14 @@ namespace NppMenuSearch.Forms
                     e.Handled = true;
                     suppressKeyPress = true;
                     break;
+
+                case Keys.Back:
+                    if (e.Control)
+                    {
+                        // Ctrl+BackSpace
+                        txtSearch.Text = "";
+                    }
+                    break;
             }
         }
 
@@ -330,6 +338,14 @@ namespace NppMenuSearch.Forms
             {
                 suppressKeyPress = false;
                 e.Handled = true;
+            }
+            else
+            {
+                if (e.KeyChar == '\x7F') // 0x7F corresponds to Ctrl+BackSpace. Why? Ask Microsoft...
+                {
+                    e.KeyChar = '\x00';
+                    e.Handled = true;
+                }
             }
         }
 

--- a/NppMenuSearch/Forms/ToolbarSearchForm.cs
+++ b/NppMenuSearch/Forms/ToolbarSearchForm.cs
@@ -302,6 +302,15 @@ namespace NppMenuSearch.Forms
 
         private bool suppressKeyPress;
 
+        private string RemoveLastWord(string S)
+        {
+            int n = S.Length - 1;
+            while (n >= 0 && Char.IsWhiteSpace(S[n])) { --n; } // skipping the trailing spaces
+            while (n >= 0 && !Char.IsWhiteSpace(S[n])) { --n; } // skipping the last word
+            while (n >= 0 && Char.IsWhiteSpace(S[n])) { --n; } // skipping the spaces before the last word
+            return (n >= 0) ? S.Substring(0, n + 1) : "";
+        }
+
         private void txtSearch_KeyDown(object sender, KeyEventArgs e)
         {
             suppressKeyPress = false;
@@ -326,7 +335,9 @@ namespace NppMenuSearch.Forms
                     if (e.Control)
                     {
                         // Ctrl+BackSpace
-                        txtSearch.Text = "";
+                        txtSearch.Text = RemoveLastWord(txtSearch.Text);
+                        int n = txtSearch.Text.Length;
+                        txtSearch.Select(n, n);
                     }
                     break;
             }

--- a/NppMenuSearch/Forms/ToolbarSearchForm.cs
+++ b/NppMenuSearch/Forms/ToolbarSearchForm.cs
@@ -302,15 +302,6 @@ namespace NppMenuSearch.Forms
 
         private bool suppressKeyPress;
 
-        private string RemovePrevioustWord(string S, int pos)
-        {
-            int n = ((pos <= S.Length) ? pos : S.Length) - 1;
-            while (n >= 0 && Char.IsWhiteSpace(S[n])) { --n; } // skipping the trailing spaces
-            while (n >= 0 && !Char.IsWhiteSpace(S[n])) { --n; } // skipping the last word
-            while (n >= 0 && Char.IsWhiteSpace(S[n])) { --n; } // skipping the spaces before the last word
-            return S.Substring(0, n + 1) + S.Substring(pos);
-        }
-
         private void txtSearch_KeyDown(object sender, KeyEventArgs e)
         {
             suppressKeyPress = false;
@@ -335,11 +326,12 @@ namespace NppMenuSearch.Forms
                     if (e.Control)
                     {
                         // Ctrl+BackSpace
+                        suppressKeyPress = true; // Ctrl+BackSpace triggers a KeyPress with e.KeyChar == '\x7F'
                         int pos = txtSearch.SelectionStart;
                         if (txtSearch.SelectionLength == 0)
                         {
                             int len = txtSearch.Text.Length;
-                            txtSearch.Text = RemovePrevioustWord(txtSearch.Text, pos);
+                            txtSearch.Text = txtSearch.Text.RemovePrevioustWord(pos);
                             pos -= (len - txtSearch.Text.Length);
                         }
                         else
@@ -358,14 +350,6 @@ namespace NppMenuSearch.Forms
             {
                 suppressKeyPress = false;
                 e.Handled = true;
-            }
-            else
-            {
-                if (e.KeyChar == '\x7F') // 0x7F corresponds to Ctrl+BackSpace. Why? Ask Microsoft...
-                {
-                    e.KeyChar = '\x00';
-                    e.Handled = true;
-                }
             }
         }
 

--- a/NppMenuSearch/Forms/ToolbarSearchForm.cs
+++ b/NppMenuSearch/Forms/ToolbarSearchForm.cs
@@ -331,7 +331,7 @@ namespace NppMenuSearch.Forms
                         if (txtSearch.SelectionLength == 0)
                         {
                             int len = txtSearch.Text.Length;
-                            txtSearch.Text = txtSearch.Text.RemovePrevioustWord(pos);
+                            txtSearch.Text = txtSearch.Text.RemovePreviousWord(pos);
                             pos -= (len - txtSearch.Text.Length);
                         }
                         else

--- a/NppMenuSearch/Forms/ToolbarSearchForm.cs
+++ b/NppMenuSearch/Forms/ToolbarSearchForm.cs
@@ -302,13 +302,13 @@ namespace NppMenuSearch.Forms
 
         private bool suppressKeyPress;
 
-        private string RemoveLastWord(string S)
+        private string RemovePrevioustWord(string S, int pos)
         {
-            int n = S.Length - 1;
+            int n = ((pos <= S.Length) ? pos : S.Length) - 1;
             while (n >= 0 && Char.IsWhiteSpace(S[n])) { --n; } // skipping the trailing spaces
             while (n >= 0 && !Char.IsWhiteSpace(S[n])) { --n; } // skipping the last word
             while (n >= 0 && Char.IsWhiteSpace(S[n])) { --n; } // skipping the spaces before the last word
-            return (n >= 0) ? S.Substring(0, n + 1) : "";
+            return S.Substring(0, n + 1) + S.Substring(pos);
         }
 
         private void txtSearch_KeyDown(object sender, KeyEventArgs e)
@@ -335,9 +335,18 @@ namespace NppMenuSearch.Forms
                     if (e.Control)
                     {
                         // Ctrl+BackSpace
-                        txtSearch.Text = RemoveLastWord(txtSearch.Text);
-                        int n = txtSearch.Text.Length;
-                        txtSearch.Select(n, n);
+                        int pos = txtSearch.SelectionStart;
+                        if (txtSearch.SelectionLength == 0)
+                        {
+                            int len = txtSearch.Text.Length;
+                            txtSearch.Text = RemovePrevioustWord(txtSearch.Text, pos);
+                            pos -= (len - txtSearch.Text.Length);
+                        }
+                        else
+                        {
+                            txtSearch.Text = txtSearch.Text.Substring(0, pos) + txtSearch.Text.Substring(pos + txtSearch.SelectionLength);
+                        }
+                        txtSearch.Select(pos, 0);
                     }
                     break;
             }

--- a/NppMenuSearch/StringUtil.cs
+++ b/NppMenuSearch/StringUtil.cs
@@ -144,7 +144,7 @@ namespace NppMenuSearch
             return sb.ToString();
         }
 
-        public static string RemovePrevioustWord(this string s, int pos)
+        public static string RemovePreviousWord(this string s, int pos)
         {
             int n = ((pos <= s.Length) ? pos : s.Length) - 1;
             while (n >= 0 && Char.IsWhiteSpace(s[n])) { --n; } // skipping the trailing spaces

--- a/NppMenuSearch/StringUtil.cs
+++ b/NppMenuSearch/StringUtil.cs
@@ -143,5 +143,14 @@ namespace NppMenuSearch
                 sb.Append(s);
             return sb.ToString();
         }
+
+        public static string RemovePrevioustWord(this string s, int pos)
+        {
+            int n = ((pos <= s.Length) ? pos : s.Length) - 1;
+            while (n >= 0 && Char.IsWhiteSpace(s[n])) { --n; } // skipping the trailing spaces
+            while (n >= 0 && !Char.IsWhiteSpace(s[n])) { --n; } // skipping the last word
+            while (n >= 0 && Char.IsWhiteSpace(s[n])) { --n; } // skipping the spaces before the last word
+            return s.Substring(0, n + 1) + s.Substring(pos);
+        }
     }
 }


### PR DESCRIPTION
When Ctrl+BackSpace is pressed, an unreadable symbol is added to the text in the txtSearch.
This is the standard behavior of Windows edit control, though it would make much more sense to make Ctrl+BackSpace to delete a previous word similarly to how Ctrl+Delete deletes a next word.
This pull request makes Ctrl+BackSpace to delete the previous word from the caret in txtSearch.